### PR TITLE
Fixed #18389 -- Fixed the way contribute_to_class is called

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import copy
+import inspect
 import sys
 from functools import update_wrapper
 import warnings
@@ -299,7 +300,8 @@ class ModelBase(type):
                 cls.add_to_class(mgr_name, new_manager)
 
     def add_to_class(cls, name, value):
-        if hasattr(value, 'contribute_to_class'):
+        # We should call the contirbute_to_class method only if it's bound
+        if not inspect.isclass(value) and hasattr(value, 'contribute_to_class'):
             value.contribute_to_class(cls, name)
         else:
             setattr(cls, name, value)

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -145,10 +145,20 @@ class VerboseNameField(models.Model):
     field22 = models.URLField("verbose field22")
 
 
-# This model isn't used in any test, just here to ensure it validates successfully.
+###############################################################################
+# These models aren't used in any test, just here to ensure they validate
+# successfully.
+
 # See ticket #16570.
 class DecimalLessThanOne(models.Model):
     d = models.DecimalField(max_digits=3, decimal_places=3)
+
+
+# See ticket #18389.
+class FieldClassAttributeModel(models.Model):
+    field_class = models.CharField
+
+###############################################################################
 
 
 class DataModel(models.Model):


### PR DESCRIPTION
Now this method is only called only if the object is an instance.
This allows to have field classes as model class attributes.
